### PR TITLE
Generates expected number of metrics now

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ for details.
 
 ## Building from source
 
-    go get -u github.com/redhat-nfvpe/telemetry-bench
-    cd $GOPATH/src/github.com/redhat-nfvpe/telemetry-bench
+    go get -u github.com/redhat-service-assurance/telemetry-bench/...
+    cd $GOPATH/src/github.com/redhat-service-assurance/telemetry-bench
     dep ensure -v -vendor-only
     go build cmd/telemetry-bench.go
 

--- a/cmd/telemetry-bench.go
+++ b/cmd/telemetry-bench.go
@@ -176,7 +176,7 @@ func generateHosts(hostPrefix *string, numHosts int, numPlugins int, intervalSec
 			typeInstance:   []string{""},
 		}
 
-		for j := 1; j < numPlugins; j++ {
+		for j := 1; j < numPlugins+1; j++ {
 			hosts[i].plugins[j].name = fmt.Sprintf(metricsTemplate, j)
 			hosts[i].plugins[j].interval = intervalSec
 			hosts[i].plugins[j].hostname = &hosts[i].name
@@ -185,11 +185,11 @@ func generateHosts(hostPrefix *string, numHosts int, numPlugins int, intervalSec
 				hosts[i].plugins[j].mtype[k] = fmt.Sprintf("type%d", k)
 			}
 			hosts[i].plugins[j].typeInstance = make([]string, numTypeInstances)
-			for k := 0; k < numTypes; k++ {
+			for k := 0; k < numTypeInstances; k++ {
 				hosts[i].plugins[j].typeInstance[k] = fmt.Sprintf("typInst%d", k)
 			}
 			hosts[i].plugins[j].pluginInstance = make([]string, numPluginInstances)
-			for k := 0; k < numTypes; k++ {
+			for k := 0; k < numPluginInstances; k++ {
 				hosts[i].plugins[j].pluginInstance[k] = fmt.Sprintf("pluginInst%d", k)
 			}
 			hosts[i].plugins[j].values = []pluginFunc{randomFloatFunc}


### PR DESCRIPTION
* Adjusted go get command and paths
* An extra metric per host per intervale is generated for the uptime
* I might write another PR to make the uptime metric optional

# Testing 

```
[csibbitt@laptop telemetry-bench (csibbitt-5-fix-generator) ]$ ./telemetry-bench -hostprefix test020- -hosts 1 -plugins 2 -instances 10 -verbose -timepermesgs 1 amqp://localhost:5672/collectd/telemetry/
Send 20 metrics every 1 second(s)Total sent (0)0, total 0, 0 ack'd
Generated 21 metrics in 143.618µs
(0): Sent 1 metrics in 682.122213ms, ( 682122.213 uS per metric )
(0): Sent 1 metrics in 116.282µs, ( 116.282 uS per metric )
(0): Sent 1 metrics in 282.827µs, ( 282.827 uS per metric )
(0): Sent 1 metrics in 314.054µs, ( 314.054 uS per metric )
(0): Sent 1 metrics in 120.393µs, ( 120.393 uS per metric )
(0): Sent 1 metrics in 182.805µs, ( 182.805 uS per metric )
(0): Sent 1 metrics in 250.591µs, ( 250.591 uS per metric )
(0): Sent 1 metrics in 120.518µs, ( 120.518 uS per metric )
(0): Sent 1 metrics in 318.614µs, ( 318.614 uS per metric )
(0): Sent 1 metrics in 168.804µs, ( 168.804 uS per metric )
(0): Sent 1 metrics in 213.641µs, ( 213.641 uS per metric )
(0): Sent 1 metrics in 141.315µs, ( 141.315 uS per metric )
(0): Sent 1 metrics in 122.527µs, ( 122.527 uS per metric )
(0): Sent 1 metrics in 103.604µs, ( 103.604 uS per metric )
(0): Sent 1 metrics in 90.381µs, ( 90.381 uS per metric )
(0): Sent 1 metrics in 198.682µs, ( 198.682 uS per metric )
(0): Sent 1 metrics in 165.344µs, ( 165.344 uS per metric )
(0): Sent 1 metrics in 132.709µs, ( 132.709 uS per metric )
(0): Sent 1 metrics in 115.086µs, ( 115.086 uS per metric )
(0): Sent 1 metrics in 139.553µs, ( 139.553 uS per metric )
(0): Sent 1 metrics in 103.241µs, ( 103.241 uS per metric )
done...
```

Then in prometheus `{exported_instance=~"test020-.*", type=~".+"}[10m]` shows me the expected 21 metrics:

```

sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst0",service="cloud1-smartgateway",type="typInst0"} | 0.7287 @1568317941.414
-- | --
sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst1",service="cloud1-smartgateway",type="typInst0"} | 0.0632 @1568317941.414
sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst2",service="cloud1-smartgateway",type="typInst0"} | 0.3497 @1568317941.414
sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst3",service="cloud1-smartgateway",type="typInst0"} | 0.2308 @1568317941.414
sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst4",service="cloud1-smartgateway",type="typInst0"} | 0.7395 @1568317941.414
sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst5",service="cloud1-smartgateway",type="typInst0"} | 0.1097 @1568317941.414
sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst6",service="cloud1-smartgateway",type="typInst0"} | 0.5225 @1568317941.414
sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst7",service="cloud1-smartgateway",type="typInst0"} | 0.2111 @1568317941.414
sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst8",service="cloud1-smartgateway",type="typInst0"} | 0.8626 @1568317941.414
sa_collectd_metrics001_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics001="pluginInst9",service="cloud1-smartgateway",type="typInst0"} | 0.3392 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst0",service="cloud1-smartgateway",type="typInst0"} | 0.2033 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst1",service="cloud1-smartgateway",type="typInst0"} | 0.5021 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst2",service="cloud1-smartgateway",type="typInst0"} | 0.2735 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst3",service="cloud1-smartgateway",type="typInst0"} | 0.5808 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst4",service="cloud1-smartgateway",type="typInst0"} | 0.7702 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst5",service="cloud1-smartgateway",type="typInst0"} | 0.6435 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst6",service="cloud1-smartgateway",type="typInst0"} | 0.7575 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst7",service="cloud1-smartgateway",type="typInst0"} | 0.3033 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst8",service="cloud1-smartgateway",type="typInst0"} | 0.3744 @1568317941.414
sa_collectd_metrics002_type0_samples_total{endpoint="prom-http",exported_instance="test020-hostname000",metrics002="pluginInst9",service="cloud1-smartgateway",type="typInst0"} | 0.1471 @1568317941.414
sa_collectd_uptime{endpoint="prom-http",exported_instance="test020-hostname000",service="cloud1-smartgateway",type="base",uptime="base"} | 0 @1568317941.414
```

Fixes #5 